### PR TITLE
Remove docker checks for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
   target-branch: develop
   labels:
   - dependencies
-- package-ecosystem: docker
-  directory: "/docker"
-  schedule:
-      interval: daily
-  target-branch: develop
-  labels:
-  - docker_dependencies


### PR DESCRIPTION
This PR will remove docker checks by dependabot as suggested in [this comment](https://github.com/materialscloud-org/voila-materialscloud-template/pull/10#issuecomment-702112056).