### PR TITLE
Automatic PyPI release

### DIFF
--- a/.github/static/release_tag_msg.txt
+++ b/.github/static/release_tag_msg.txt
@@ -1,0 +1,4 @@
+TAG_NAME
+
+This tag was created automatically through the GH Actions
+"Publish on PyPI" workflow.

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,0 +1,57 @@
+name: Publish on PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'materialscloud-org/voila-materialscloud-template' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
+        pip install -U invoke
+
+    - name: Update version
+      run: invoke update-version --version="${GITHUB_REF#refs/tags/}"
+
+    - name: Create new tag
+      run: |
+        git config --local user.email "dev@materialscloud.org"
+        git config --local user.name "Materials Cloud Team"
+
+        git commit -m "Release ${GITHUB_REF#refs/tags/}" -a
+
+        TAG_MSG=.github/static/release_tag_msg.txt
+        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|g" "${TAG_MSG}"
+
+        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+
+    - name: Push release commit and new tag
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tags: true
+        branch: develop
+
+    - name: Build source distribution
+      run: python ./setup.py sdist
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.md
 recursive-include share *
 include copy_voila_template.py
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+invoke==1.4.1
 ipywidgets==7.5.1
 voila==0.2.3
 widget-periodictable==2.1.5

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import re
+import sys
+from typing import Tuple
+
+from invoke import task
+
+
+TOP_DIR = Path(__file__).parent.resolve()
+
+
+def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
+    """Utility function for tasks to read, update, and write files"""
+    with open(filename, "r") as handle:
+        lines = [
+            re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
+        ]
+
+    with open(filename, "w") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+@task
+def update_version(_, version=""):
+    """Update package version using SemVer syntax."""
+    if version:
+        if version.startswith("v"):
+            version = version[1:]
+        if re.match(r"[0-9]+(\.[0-9]+){2}.*", version) is None:
+            sys.exit(
+                f"Error: Passed version ({version}) does to match the SemVer format: "
+                "Major.Minor.Patch(+ extras)."
+            )
+    else:
+        sys.exit(
+            "Please pass --version with a value that complies to the SemVer format: "
+            "Major.Minor.Patch(+ extras)."
+        )
+
+    update_file(
+        TOP_DIR.joinpath("setup.py"), (r"version=.*,", f"version='{version}',")
+    )
+
+    print(f"Bumped version to {version} !")


### PR DESCRIPTION
This may be a bit overkill for this repository, but never the less do we now have a PyPI release that is a different version from the one specified in `setup.py` (`0.2.1` vs. `0.2.0`).

In order to combat this from happening in the future, I have created a GitHub Actions workflow that will update the version in `setup.py`, create the source distribution, a versioned tag, and release to PyPI all automatically.

The only thing one has to do is publish a GitHub release with the correct name: `v<MAJOR>.<MINOR>.<PATCH>(+ extras)`.
Where major, minor, and patch are version numbers according to semantic versioning (SemVer), e.g., `v1.0.5`.

Also, we need to add a PyPI API password as a secret for this repository.

---

This PR is motivated by the fact that the special post-install function doesn't run for wheel distributions, and when installing with the `--no-binaries :all:` option, it complained that it couldn't find `requirements.txt` in the source distribution. So I have added `requirements.txt` to the `MANIFEST.in` and this workflow will ensure we don't build wheel's, but only upload source distributions to PyPI. All in all this should ensure the special post-install function is run correctly, and the template is copied into the Jupyter data config directory as intended.