### PR TITLE
Using the MaterialsCloud loading logo and eliminate loading spinner when toggling between pages 

### DIFF
--- a/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
+++ b/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
@@ -37,10 +37,6 @@ body {
   width: 100%;
 }
 
-.voila-spinner-color1{
-  fill: {{ bar_color }};
-}
-
 a.anchor-link {
   display: none;
 }
@@ -360,8 +356,8 @@ a.jupyter-widgets.jupyter-button:disabled {
 
 {%- endblock html_head_css -%}
 
-{%- block body -%}
 {%- block body_header -%}
+  {{ super() }}
   <header>
     <div class="mcloud-header header" id="mcloudHeader">
       <div class="navbar navbar-default navbar-static-top">
@@ -399,24 +395,24 @@ a.jupyter-widgets.jupyter-button:disabled {
 {%- endblock body_header -%}
 
 {%- block body_loop -%}
-        {% if resources.theme == 'dark' %}
-        <div class="jp-Notebook theme-dark">
-        {% else %}
-        <div class="jp-Notebook theme-light">
-        {% endif %}
-          <ol class="breadcrumb ng-isolate-scope" ncy-breadcrumb="">
-            <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope" style="">
-              <a ng-switch-when="false" href="https://www.materialscloud.org/work/" class="ng-binding ng-scope" style="">Work</a>
-            </li>
-            <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope" style="">
-              <a ng-switch-when="false" href="https://www.materialscloud.org/work/tools" class="ng-binding ng-scope" style="">Tools</a>
-            </li>
-            <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope active" style="">
-              <span ng-switch-when="true" class="ng-binding ng-scope">{{nb_title}}</span>
-            </li>
-          </ol>
-          {{ super() }}
-        </div>
+          {% if resources.theme == 'dark' %}
+          <div class="jp-Notebook theme-dark">
+          {% else %}
+          <div class="jp-Notebook theme-light">
+          {% endif %}
+            <ol class="breadcrumb ng-isolate-scope" ncy-breadcrumb="">
+              <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope" style="">
+                <a ng-switch-when="false" href="https://www.materialscloud.org/work/" class="ng-binding ng-scope" style="">Work</a>
+              </li>
+              <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope" style="">
+                <a ng-switch-when="false" href="https://www.materialscloud.org/work/tools" class="ng-binding ng-scope" style="">Tools</a>
+              </li>
+              <li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract" class="ng-scope active" style="">
+                <span ng-switch-when="true" class="ng-binding ng-scope">{{nb_title}}</span>
+              </li>
+            </ol>
+            {{ super() }}
+          </div>
 {%- endblock body_loop -%}
 
 {%- block body_footer -%}
@@ -427,5 +423,3 @@ a.jupyter-widgets.jupyter-button:disabled {
   {{ super() }}
   {{ resources.include_js("static/js/materialize.min.js") }}
 {%- endblock body_footer -%}
-
-{%- endblock body -%}

--- a/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
+++ b/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
@@ -362,7 +362,6 @@ a.jupyter-widgets.jupyter-button:disabled {
 
 {%- block body -%}
 {%- block body_header -%}
-  {{ super() }}
   <header>
     <div class="mcloud-header header" id="mcloudHeader">
       <div class="navbar navbar-default navbar-static-top">

--- a/share/jupyter/nbconvert/templates/materialscloud/static/images/mcloud_spinner.svg
+++ b/share/jupyter/nbconvert/templates/materialscloud/static/images/mcloud_spinner.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="88.923645"
+   height="71.767258"
+   viewBox="0 0 88.923644 71.767261"
+   id="svg9098"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="mcloud_spinner.svg">
+  <defs
+     id="defs9100" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="43.745989"
+     inkscape:cy="31.229882"
+     inkscape:document-units="px"
+     inkscape:current-layer="g9"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1337"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     fit-margin-top="3"
+     fit-margin-left="3"
+     fit-margin-right="3"
+     fit-margin-bottom="3" />
+  <metadata
+     id="metadata9103">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(20.149549,-1001.3136)">
+    <g
+       id="mctriangle"
+       transform="matrix(1.1533275,0,0,1.1556928,-379.094,391.20844)">
+      <g
+         transform="translate(2975.41,266.50511)"
+         style="display:inline;stroke:#d21f15;stroke-width:0.86616874;stroke-opacity:1"
+         id="layer6" />
+      <g
+         id="g9">
+        <g
+           id="g843"
+           transform="matrix(2.7629851,0,0,2.7629851,-594.33955,-968.57896)">
+          <path
+             id="path9220"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88989985;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.49344,550.22655 c 0,-3.98781 3.228,-7.22068 7.20861,-7.22068 3.98022,0 7.20707,3.23287 7.20707,7.22068"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9224"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.49344,550.41953 c -2.95932,0 -5.36014,2.46332 -5.36014,5.50321 0,3.0399 2.40082,5.50322 5.36014,5.50322"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9228"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 348.90912,550.41953 c 2.95932,0 5.36014,2.46332 5.36014,5.50321 0,3.0399 -2.40082,5.50322 -5.36014,5.50322"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9232"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.45731,561.42596 h 14.46834"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9236"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88989985;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.49344,550.22655 c 0,-3.98781 3.228,-7.22068 7.20861,-7.22068 3.98022,0 7.20707,3.23287 7.20707,7.22068"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9240"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.49344,550.41953 c -2.95932,0 -5.36014,2.46332 -5.36014,5.50321 0,3.0399 2.40082,5.50322 5.36014,5.50322"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9244"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 348.90912,550.41953 c 2.95932,0 5.36014,2.46332 5.36014,5.50321 0,3.0399 -2.40082,5.50322 -5.36014,5.50322"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path9248"
+             style="fill:none;stroke:#d21f15;stroke-width:0.88643086;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 334.45731,561.42596 h 14.46834"
+             inkscape:connector-curvature="0" />
+          <ellipse
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="ref"
+             cx="341.70126"
+             cy="553.91522"
+             rx="0.26011693"
+             ry="0.25958455" />
+          <path
+             inkscape:connector-curvature="0"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#d21f15;stroke-width:0.91575587;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 335.13723,550.18801 3.282,5.47638 3.28206,5.47638 3.28203,-5.47638 3.28203,-5.47638 h -6.56406 z"
+             id="mctriangleonly" />
+          <circle
+             r="1.4070433"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#d21f15;stroke-width:0.88349211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="circle7840-5"
+             cx="348.39252"
+             cy="550.02032" />
+          <circle
+             r="1.4070433"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#d21f15;stroke-width:0.88349211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="circle7842-0"
+             cx="335.01007"
+             cy="550.02032" />
+          <circle
+             r="1.4070433"
+             cy="561.30841"
+             cx="341.70132"
+             id="circle7844-5"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#d21f15;stroke-width:0.88349211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+          <circle
+             cy="550.02032"
+             cx="335.01007"
+             id="movingcircle"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#d21f15;stroke-width:0.88349211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             r="1.4070433">
+            <animateTransform
+               attributeName="transform"
+               type="translate"
+               values="0.0 0.0;13.38245  0.0;6.69125 11.28809;0.0 0.0"
+               dur="1s"
+               begin="0s"
+               repeatCount="indefinite"
+               id="anim1" />
+          </circle>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/share/jupyter/voila/templates/materialscloud/base.html
+++ b/share/jupyter/voila/templates/materialscloud/base.html
@@ -1,12 +1,3 @@
-{% macro spinner() -%}
-  <div class="loading">
-    <div class="spinner-container">
-      <svg class="spinner" data-name="c1" version="1.1" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><metadata><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title>voila</dc:title></cc:Work></rdf:RDF></metadata><title>spin</title><path class="voila-spinner-color1" d="m250 405c-85.47 0-155-69.53-155-155s69.53-155 155-155 155 69.53 155 155-69.53 155-155 155zm0-275.5a120.5 120.5 0 1 0 120.5 120.5 120.6 120.6 0 0 0-120.5-120.5z"/><path class="voila-spinner-color2" d="m250 405c-85.47 0-155-69.53-155-155a17.26 17.26 0 1 1 34.51 0 120.6 120.6 0 0 0 120.5 120.5 17.26 17.26 0 1 1 0 34.51z"/></svg>
-    </div>
-    {{ caller() }}
-  </div>
-{%- endmacro %}
-
 {% macro spinner_mcloud() -%}
   <div class="loading">
     <div class="spinner-container">

--- a/share/jupyter/voila/templates/materialscloud/base.html
+++ b/share/jupyter/voila/templates/materialscloud/base.html
@@ -1,8 +1,6 @@
-{% macro spinner_mcloud() -%}
+{% macro spinner() -%}
   <div class="loading">
-    <div class="spinner-container">
-        <img style="width: 150px; text-align: center;" src="{{ base_url }}voila/static/images/mcloud_spinner.svg"></img> 
-    </div>
+      <img style="width: 150px; text-align: center;" src="{{ base_url }}voila/static/images/mcloud_spinner.svg"/>
     {{ caller() }}
   </div>
 {%- endmacro %}

--- a/share/jupyter/voila/templates/materialscloud/base.html
+++ b/share/jupyter/voila/templates/materialscloud/base.html
@@ -7,6 +7,15 @@
   </div>
 {%- endmacro %}
 
+{% macro spinner_mcloud() -%}
+  <div class="loading">
+    <div class="spinner-container">
+        <img style="width: 150px; text-align: center;" src="{{ base_url }}voila/static/images/mcloud_spinner.svg"></img> 
+    </div>
+    {{ caller() }}
+  </div>
+{%- endmacro %}
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/share/jupyter/voila/templates/materialscloud/browser-open.html
+++ b/share/jupyter/voila/templates/materialscloud/browser-open.html
@@ -5,9 +5,9 @@
 {% endblock %}
 
 {% block body %}
-  {% call spinner_mcloud() %}
+  {% call spinner() %}
     <h5>
-    This page should redirect you to voila. If it doesn't, <a href="{{ open_url }}">click here to go to voila</a>.
+      This page should redirect you to voila. If it doesn't, <a href="{{ open_url }}">click here to go to voila</a>.
     </h5>
   {% endcall %}
 {% endblock %}

--- a/share/jupyter/voila/templates/materialscloud/browser-open.html
+++ b/share/jupyter/voila/templates/materialscloud/browser-open.html
@@ -7,7 +7,7 @@
 {% block body %}
   {% call spinner_mcloud() %}
     <h5>
-      This page should redirect you to voila. If it doesn't, <a href="{{ open_url }}">click here to go to voila</a>.
+        Loading ... 
     </h5>
   {% endcall %}
 {% endblock %}

--- a/share/jupyter/voila/templates/materialscloud/browser-open.html
+++ b/share/jupyter/voila/templates/materialscloud/browser-open.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block body %}
-  {% call spinner() %}
+  {% call spinner_mcloud() %}
     <h5>
       This page should redirect you to voila. If it doesn't, <a href="{{ open_url }}">click here to go to voila</a>.
     </h5>

--- a/share/jupyter/voila/templates/materialscloud/browser-open.html
+++ b/share/jupyter/voila/templates/materialscloud/browser-open.html
@@ -7,7 +7,7 @@
 {% block body %}
   {% call spinner_mcloud() %}
     <h5>
-        Loading ... 
+    This page should redirect you to voila. If it doesn't, <a href="{{ open_url }}">click here to go to voila</a>.
     </h5>
   {% endcall %}
 {% endblock %}

--- a/share/jupyter/voila/templates/materialscloud/index.html.j2
+++ b/share/jupyter/voila/templates/materialscloud/index.html.j2
@@ -41,9 +41,7 @@
     pointer-events: auto;
   }
 </style>
-
 {%- endblock html_head_css -%}
-
 
 {% block footer_js %}
   {{ super() }}

--- a/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
+++ b/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
@@ -1,0 +1,21 @@
+{% macro css() %}
+  <!-- materialscloud loading animation -->
+  <style>
+    #loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 75vh;
+        font-family: sans-serif;
+    }
+  </style>
+{% endmacro %}
+
+{% macro html() %}
+  <div id="loading">
+    <img style="width: 150px; text-align: center;" src="/voila/static/images/mcloud_spinner.svg"/>
+    <h2 id="loading_text">Running {{nb_title}}...</h2>
+    This page should redirect you. If it doesn't, <a href="{{ open_url }}">click here</a>.
+  </div>
+{% endmacro %}


### PR DESCRIPTION
I found there are two spinners appearing in the template. One is from the base.html and the other is from the default for lab. 
I think there is no need to show the spinner when toggling between different notebooks. So I remove it. The MaterialsCloud
loading spinner will only be shown at the beginning. 