### PR TITLE
Properly locate MaterialsCloud spinner SVG

### DIFF
--- a/share/jupyter/nbconvert/templates/materialscloud-iframe/index.html.j2
+++ b/share/jupyter/nbconvert/templates/materialscloud-iframe/index.html.j2
@@ -363,7 +363,24 @@ a.jupyter-widgets.jupyter-button:disabled {
 {%- endblock html_head_css -%}
 
 {%- block body_header -%}
-  {{ super() }}
+  <!-- Copy of body_header from voila/templates/lab/index.html.j2 -->
+  {% if resources.theme == 'dark' %}
+  <body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
+  {% else %}
+  <body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
+  {% endif %}
+  {{ spinner.html(resources.base_url) }}  <!-- Special line needed to locate MaterialsCloud spinner - this is the reason not to use super() -->
+  <script>
+  var voila_process = function(cell_index, cell_count) {
+    var el = document.getElementById("loading_text")
+    el.innerHTML = `Executing ${cell_index} of ${cell_count}`
+  }
+  var voila_heartbeat = function() {
+    console.log('Ok, voila is still executing...')
+  }
+  </script>
+  <div id="rendered_cells" style="display: none">
+
   <div class="container">
 {%- endblock body_header -%}
 

--- a/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
+++ b/share/jupyter/nbconvert/templates/materialscloud/index.html.j2
@@ -357,7 +357,25 @@ a.jupyter-widgets.jupyter-button:disabled {
 {%- endblock html_head_css -%}
 
 {%- block body_header -%}
-  {{ super() }}
+  <!-- Copy of body_header from voila/templates/lab/index.html.j2 -->
+  {% if resources.theme == 'dark' %}
+  <body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
+  {% else %}
+  <body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
+  {% endif %}
+  {{ spinner.html(resources.base_url) }}  <!-- Special line needed to locate MaterialsCloud spinner - this is the reason not to use super() -->
+  <script>
+  var voila_process = function(cell_index, cell_count) {
+    var el = document.getElementById("loading_text")
+    el.innerHTML = `Executing ${cell_index} of ${cell_count}`
+  }
+  var voila_heartbeat = function() {
+    console.log('Ok, voila is still executing...')
+  }
+  </script>
+  <div id="rendered_cells" style="display: none">
+  
+  <!-- MaterialsCloud header -->
   <header>
     <div class="mcloud-header header" id="mcloudHeader">
       <div class="navbar navbar-default navbar-static-top">

--- a/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
+++ b/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
@@ -14,7 +14,7 @@
 
 {% macro html() %}
   <div id="loading">
-    <img style="width: 150px; text-align: center;" src="../static/images/mcloud_spinner.svg"/>
+    <img style="width: 150px; text-align: center;" src="{{ base_url }}voila/static/images/mcloud_spinner.svg"/>
     <h2 id="loading_text">Running {{nb_title}}...</h2>
     This page should redirect you. If it doesn't, <a href="{{ open_url }}">click here</a>.
   </div>

--- a/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
+++ b/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
@@ -14,7 +14,7 @@
 
 {% macro html() %}
   <div id="loading">
-    <img style="width: 150px; text-align: center;" src="/voila/static/images/mcloud_spinner.svg"/>
+    <img style="width: 150px; text-align: center;" src="../static/images/mcloud_spinner.svg"/>
     <h2 id="loading_text">Running {{nb_title}}...</h2>
     This page should redirect you. If it doesn't, <a href="{{ open_url }}">click here</a>.
   </div>

--- a/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
+++ b/share/jupyter/voila/templates/materialscloud/spinner.macro.html.j2
@@ -12,7 +12,7 @@
   </style>
 {% endmacro %}
 
-{% macro html() %}
+{% macro html(base_url) %}
   <div id="loading">
     <img style="width: 150px; text-align: center;" src="{{ base_url }}voila/static/images/mcloud_spinner.svg"/>
     <h2 id="loading_text">Running {{nb_title}}...</h2>


### PR DESCRIPTION
Fixes #20 

Check solution on [binder](https://mybinder.org/v2/gh/materialscloud-org/voila-materialscloud-template/fix_20_spinner-broken-in-binder?urlpath=%2Fvoila%2Frender%2Fexample-notebooks%2Fexample.ipynb).

The solution to make sure the correct base URL is always located, is to utilize the `resources` variable. However, this is not available in the spinner macro. To overcome this, I am now passing in the `resources.base_url` in the `spinner.html()` macro, which I can only do by "commandeering" the code where `spinner.html()` is called. Since this is done in the `lab` Voilà template, I have copied over the relevant `body_header` block and changed the line that needed changing.
Furthermore, the spinner macro, specifically the `spinner.html()` macro now takes the added `base_url` parameter as input.

This has been tested both locally and on binder and seems to work as intended.